### PR TITLE
Updated SafeConfigParser to ConfigParser

### DIFF
--- a/pyro
+++ b/pyro
@@ -5,7 +5,7 @@
 #  
 import os
 import logging.handlers
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from shutil import copyfile
 from glob import glob
 import errno
@@ -26,7 +26,7 @@ def main():
 		raise OSError(errno.ENOENT,msg)
 
 
-	parser = SafeConfigParser()
+	parser = ConfigParser()
 	parser.read(CONFIG_FILE)
 
 	rotated_logger = logging.getLogger('pyroLogger')

--- a/pyrorc
+++ b/pyrorc
@@ -2,6 +2,6 @@
 # backupCount - at most backupCount files will be kept (0 means no limit)
 
 [bash]
-file = $HOME/.bash_history
+file = $HOME/bash_history/.bash_history
 backupCount = 0
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from distutils.core import setup
 
 setup(name='pyro',
-	version='0.2',
+	version='0.3',
 	description='Python file rotater',
 	author='Dustin Dorroh',
 	author_email='dustin.dorroh@decisionsciencescorp.com',


### PR DESCRIPTION
SafeConfigParser is being deprecated.

Replaced with ConfigParser.

Also changed location of .bash_history files to $HOME/bash_history.